### PR TITLE
Disable comment related XML_RPC methods

### DIFF
--- a/remove-comments-absolute.php
+++ b/remove-comments-absolute.php
@@ -63,6 +63,9 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 			
 			// remove comment options in profile page
 			add_action( 'personal_options',              array( $this, 'remove_profile_items' ) );
+			
+			// replace xmlrpc methods
+			add_filter( 'xmlrpc_methods',                array( $this, 'xmlrpc_replace_methods' ) );
 		}
 		
 		/**
@@ -481,6 +484,45 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 				return '';
 			
 			return $translation;
+		}
+		
+		/**
+		 * Replace comment related XML_RPC methods.
+		 * 
+		 * @access  public
+		 * @since   
+		 * @return  array
+		 */
+		public function xmlrpc_replace_methods( $methods ) {
+
+			$comment_methods = array(
+				'wp.getCommentCount',
+				'wp.getComment',
+				'wp.getComments',
+				'wp.deleteComment',
+				'wp.editComment',
+				'wp.newComment',
+				'wp.getCommentStatusList'
+			);
+
+			foreach( $comment_methods as $method_name ) {
+				if ( isset( $methods[$method_name] ) ) {
+					$methods[$method_name] = array( $this, 'xmlrpc_placeholder_method' );
+				}
+			}
+		
+			return $methods;
+		}
+		
+		/**
+		 * XML_RPC placeholder method.
+		 * 
+		 * @access  public
+		 * @since   
+		 * @return  object
+		 */
+		public function xmlrpc_placeholder_method() {
+			return new IXR_Error( 403, __( 'Comments are disabled on this site.', 'remove_comments_absolute' ) );
 		}
 		
 	} // end class


### PR DESCRIPTION
Replaces comment related XML_RPC methods with a placeholder function.

Unfortunately but understandably the WordPress iOS app does not check if methods exist before showing their respective UI. Rather than just removing the XML_RPC methods altogether the placeholder function returns a more friendly error message.

![nicer-error-message](https://f.cloud.github.com/assets/4179791/1181660/ae5e5530-220c-11e3-8e6a-bd4201901589.png)
