### PR TITLE
Disallow comments pages direct access

### DIFF
--- a/remove-comments-absolute.php
+++ b/remove-comments-absolute.php
@@ -160,6 +160,7 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 		 * Remove meta boxes on edit pages
 		 * Remove support on all post types for comments
 		 * Remove menu-entries
+		 * Disalow comments pages direct access
 		 * 
 		 * @access  public
 		 * @since   0.0.1
@@ -190,7 +191,14 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 					remove_post_type_support( $post_type, 'trackbacks' );
 				}
 			}
-			
+			// all comments pages
+			foreach ( array( 'comment.php', 'edit-comments.php', 'moderation.php', 'options-discussion.php' ) as $comments_page ) {
+				if ( basename( $_SERVER['PHP_SELF'] ) == $comments_page ) {
+					wp_redirect( admin_url() );
+					exit;
+				}
+			}
+
 			// remove dashboard meta box for recents comments
 			remove_meta_box( 'dashboard_recent_comments', 'dashboard', 'normal' );
 		}

--- a/remove-comments-absolute.php
+++ b/remove-comments-absolute.php
@@ -168,6 +168,8 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 		 */
 		public function remove_comments() {
 			
+			global $pagenow;
+
 			// int values
 			foreach ( array( 'comments_notify', 'default_pingback_flag' ) as $option ) {
 				add_filter( 'pre_option_' . $option, '__return_zero' );
@@ -192,11 +194,10 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 				}
 			}
 			// all comments pages
-			foreach ( array( 'comment.php', 'edit-comments.php', 'moderation.php', 'options-discussion.php' ) as $comments_page ) {
-				if ( basename( $_SERVER['PHP_SELF'] ) == $comments_page ) {
-					wp_redirect( admin_url() );
-					exit;
-				}
+			$comment_pages = array( 'comment.php', 'edit-comments.php', 'moderation.php', 'options-discussion.php' );
+			if ( in_array( $pagenow, $comment_pages ) ) {
+				wp_die( __( 'Comments are disabled on this site.', 'remove_comments_absolute' ), '', array( 'response' => 403 ) );
+				exit;
 			}
 
 			// remove dashboard meta box for recents comments

--- a/remove-comments-absolute.php
+++ b/remove-comments-absolute.php
@@ -160,7 +160,7 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 		 * Remove meta boxes on edit pages
 		 * Remove support on all post types for comments
 		 * Remove menu-entries
-		 * Disalow comments pages direct access
+		 * Disallow comments pages direct access
 		 * 
 		 * @access  public
 		 * @since   0.0.1


### PR DESCRIPTION
Hi,

It seems that direct comments related pages access is still possible after plugin installation. This pull request will redirect to dashboard any trial to access the 4 pages : 
````
/wp-admin/comment.php
/wp-admin/options-discussion.php
/wp-admin/moderation.php
/wp-admin/edit-comments.php
````

Just my 2 cents to this very usefull work :)

Thank you.

Sébastien