### PR TITLE
Empty-Stringify™ comment related feed tags

### DIFF
--- a/remove-comments-absolute.php
+++ b/remove-comments-absolute.php
@@ -67,6 +67,15 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 			
 			// replace xmlrpc methods
 			add_filter( 'xmlrpc_methods',                array( $this, 'xmlrpc_replace_methods' ) );
+			
+			// Set content of <wfw:commentRss> to empty string.
+			add_filter( 'post_comments_feed_link', '__return_empty_string' );
+			
+			// Set content of <slash:comments> to empty string.
+			add_filter( 'get_comments_number', '__return_empty_string' );
+			
+			// Return empty string for post comment link, which takes care of <comments>.
+			add_filter( 'get_comments_link', '__return_empty_string' );
 		}
 		
 		/**


### PR DESCRIPTION
Doesn’t fix #21 but at least removes the content of the affected tags.