### PR TITLE
Remove ‘Discussion Settings’ help tab

### DIFF
--- a/remove-comments-absolute.php
+++ b/remove-comments-absolute.php
@@ -105,6 +105,9 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 			
 			// Remove comments popup.
 			add_filter( 'query_vars', array( $this, 'filter_query_vars' ) );
+
+			// Remove 'Discussion Settings' help tab from post edit screen.
+			add_action( 'admin_head-post.php', array( $this, 'remove_help_tabs' ), 10, 3 );
 		}
 
 		/**
@@ -635,6 +638,22 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 			}
 
 			return $public_query_vars;
+		}
+
+		/**
+		 * Remove 'Discussion Settings' help tab from post edit screen.
+		 *
+		 * @since 01/01/2016
+		 *
+		 * @access private
+		 */
+		public function remove_help_tabs() {
+
+			$current_screen = get_current_screen();
+
+			if ( $current_screen->get_help_tab( 'discussion-settings' ) ) {
+				$current_screen->remove_help_tab( 'discussion-settings' );
+			}
 		}
 
 	} // end class


### PR DESCRIPTION
Removes the ‘Discussion Settings’ tab shown in the Contextual Help menu in the post.php and post-new.php admin pages.

![pasted_image_01_01_16_11_56](https://cloud.githubusercontent.com/assets/4179791/12070594/b32a276c-b07e-11e5-896e-25c990398db9.jpg)