### PR TITLE
Replace comments.php with empty template

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -1,0 +1,1 @@
+<?php // Replacement for the theme's comments.php file.

--- a/remove-comments-absolute.php
+++ b/remove-comments-absolute.php
@@ -74,8 +74,8 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 			add_action( 'admin_bar_menu', array( $this, 'remove_admin_bar_comment_items' ), 999 );
 			add_action( 'admin_bar_menu', array( $this, 'remove_network_comment_items' ), 999 );
 
-			// Remove string on frontend in Theme.
-			add_filter( 'gettext', array( $this, 'remove_theme_string' ), 20, 2 );
+			// Replace the theme's or the core comments template with an empty one.
+			add_filter( 'comments_template', array( $this, 'comments_template' ) );
 
 			// Remove comment feed.
 			remove_action( 'wp_head', 'feed_links', 2 );
@@ -542,27 +542,15 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 		}
 
 		/**
-		 * On posts where comments are closed, the plugin will remove the text 'Comments are closed.'.
+		 * Replace the theme's or the core comments template with an empty one.
 		 *
-		 * @access public
-		 * @since  0.0.7
+		 * @access private
+		 * @since TODO
 		 *
-		 * @param string $translation Translated text.
-		 * @param string $text        Text to translate.
-		 *
-		 * @return string empty
+		 * @return string The path to the empty template file.
 		 */
-		public function remove_theme_string( $translation, $text ) {
-
-			if ( is_admin() ) {
-				return $translation;
-			}
-
-			if ( 'Comments are closed.' === $text ) {
-				return '';
-			}
-
-			return $translation;
+		public function comments_template() {
+			return plugin_dir_path( __FILE__ ) . 'comments.php';
 		}
 
 		/**


### PR DESCRIPTION
The plugin filters the ‘Comments are closed.’ string in its `remove_theme_string()` method. The theme’s comments.php template is still included which results in empty html tags. Also, existing comments for a post are still shown. This replaces the comments.php file with an empty one which takes care of both issues. Fixes #32.