### PR TITLE
Fix: Error on empty search result pages

### DIFF
--- a/remove-comments-absolute.php
+++ b/remove-comments-absolute.php
@@ -434,13 +434,17 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 			if ( is_category() ) {
 				$term = get_queried_object();
 
-				$title = sprintf( $args['cattitle' ], get_bloginfo( 'name' ), $args['separator' ], $term->name );
-				$href = get_category_feed_link( $term->term_id );
+				if ( $term && is_object($term) ) {
+					$title = sprintf( $args['cattitle' ], get_bloginfo( 'name' ), $args['separator' ], $term->name );
+					$href = get_category_feed_link( $term->term_id );
+				}
 			} elseif ( is_tag() ) {
 				$term = get_queried_object();
 
-				$title = sprintf( $args['tagtitle' ], get_bloginfo( 'name' ), $args['separator' ], $term->name );
-				$href = get_tag_feed_link( $term->term_id );
+				if ( $term && is_object($term) ) {
+					$title = sprintf( $args['tagtitle' ], get_bloginfo( 'name' ), $args['separator' ], $term->name );
+					$href = get_tag_feed_link( $term->term_id );
+				}
 			} elseif ( is_author() ) {
 				$author_id = (int) get_query_var( 'author' );
 


### PR DESCRIPTION
Hi @bueltge 👋 

Thanks for the amazing work on this! 💯 

We use this plugin on one of our client's sites and it was flooding our automated logging system with the following error/warning:

```
Error displayed: E_NOTICE - Trying to get property 'name' of non-object
File: [site_path]/app/mu-plugins/remove-comments-absolutely/remove-comments-absolute.php
```

And sometimes for trying to access `term_id` as well. I tracked it down to be happening only on the empty search result pages. Taking a look at the code, I figured it's happening because on the empty search result pages, `is_category()` returns `true`, but the value of `get_queried_object()` is `NULL`, of course. Which in turn, triggered those error messages when trying to access the properties of the term. Please see below:

<img width="1459" alt="Screenshot 2021-07-29 at 3 14 22 PM" src="https://user-images.githubusercontent.com/21854687/127480411-715f8047-842e-40b0-9e30-fd594c88d728.png">

I've added some checks for the `$term`'s value before accessing its properties and that fixes the issue for us.

Please let me know if it's an okay fix for the issue. 🙂 
Thanks!