### PR TITLE
Prevent error while calling is_singular() (too) early

### DIFF
--- a/remove-comments-absolute.php
+++ b/remove-comments-absolute.php
@@ -160,9 +160,9 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 		 * @since  0.0.1
 		 * @uses   is_singular
 		 *
-		 * @param string $posts
+		 * @param WP_Post[] $posts
 		 *
-		 * @return string $posts
+		 * @return WP_Post[] $posts Possibly empty array of post objects.
 		 */
 		public function set_comment_status( $posts ) {
 			

--- a/remove-comments-absolute.php
+++ b/remove-comments-absolute.php
@@ -98,7 +98,7 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 			add_filter( 'post_comments_feed_link', '__return_empty_string' );
 
 			// Set content of <slash:comments> to empty string.
-			add_filter( 'get_comments_number', '__return_empty_string' );
+			add_filter( 'get_comments_number', '__return_zero' );
 
 			// Return empty string for post comment link, which takes care of <comments>.
 			add_filter( 'get_comments_link', '__return_empty_string' );

--- a/remove-comments-absolute.php
+++ b/remove-comments-absolute.php
@@ -165,10 +165,25 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 		 * @return string $posts
 		 */
 		public function set_comment_status( $posts ) {
-			if ( ! empty( $posts ) && is_singular() ) {
-				$posts[ 0 ]->comment_status = 'closed';
-				$posts[ 0 ]->ping_status = 'closed';
-			}
+			
+			// 1. if no posts at all
+			if ( empty( $posts ) ) 
+				return $posts;
+
+			// 2. if not a WP_Post, we can act on
+			if ( isset( $posts[ 0 ] ) && ! is_a( $posts[ 0 ], 'WP_Post') ) 
+				return $posts;
+
+			// 3. if comments aren't supported at all by that post_type
+			if ( ! post_type_supports( get_post_type( $posts[ 0 ] ), 'comments' ))
+				return $posts;
+
+			// x. if is_singular()
+			if ( ! is_singular() )
+				return $posts;
+
+			$posts[ 0 ]->comment_status = 'closed';
+			$posts[ 0 ]->ping_status = 'closed';
 
 			return $posts;
 		}

--- a/remove-comments-absolute.php
+++ b/remove-comments-absolute.php
@@ -167,20 +167,24 @@ if ( ! class_exists( 'Remove_Comments_Absolute' ) ) {
 		public function set_comment_status( $posts ) {
 			
 			// 1. if no posts at all
-			if ( empty( $posts ) ) 
+			if ( empty( $posts ) ) {
 				return $posts;
+			}
 
 			// 2. if not a WP_Post, we can act on
-			if ( isset( $posts[ 0 ] ) && ! is_a( $posts[ 0 ], 'WP_Post') ) 
+			if ( isset( $posts[ 0 ] ) && ! is_a( $posts[ 0 ], 'WP_Post') ) {
 				return $posts;
+			}
 
 			// 3. if comments aren't supported at all by that post_type
-			if ( ! post_type_supports( get_post_type( $posts[ 0 ] ), 'comments' ))
+			if ( ! post_type_supports( get_post_type( $posts[ 0 ] ), 'comments' )){
 				return $posts;
+			}
 
 			// x. if is_singular()
-			if ( ! is_singular() )
+			if ( ! is_singular() ){
 				return $posts;
+			}
 
 			$posts[ 0 ]->comment_status = 'closed';
 			$posts[ 0 ]->ping_status = 'closed';


### PR DESCRIPTION
Some days ago I ran into a situation, where your `set_comment_status()` function had to run that early, within the lifecycle, that the used `is_singular()` was not yet defined. Resulting in error. So I had a look into the function, when and why and how it is called.

I would like to suggest some guard-keeping, to prevent such errors.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- a **Bug fix**


**What is the current behavior?** (You can also link to an open issue here)

- a **Error** occurs, described in and hopefully fixes #73 

**What is the new behavior ~~(if this is a feature change)~~?**

- **No Error**


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No changes needed.

